### PR TITLE
Unblock queues on shutdown or errors

### DIFF
--- a/source/tristanable/exceptions.d
+++ b/source/tristanable/exceptions.d
@@ -22,6 +22,12 @@ public enum ErrorType
     MANAGER_SHUTDOWN,
 
     /**
+     * If the watcher has failed
+     * to stay alive
+     */
+    WATCHER_FAILED,
+
+    /**
      * If the requested queue could not be found
      */
     QUEUE_NOT_FOUND,

--- a/source/tristanable/exceptions.d
+++ b/source/tristanable/exceptions.d
@@ -11,6 +11,11 @@ import std.conv : to;
 public enum ErrorType
 {
     /**
+     * Unset
+     */
+    UNSET,
+
+    /**
      * If the requested queue could not be found
      */
     QUEUE_NOT_FOUND,

--- a/source/tristanable/exceptions.d
+++ b/source/tristanable/exceptions.d
@@ -16,6 +16,12 @@ public enum ErrorType
     UNSET,
 
     /**
+     * If the manager has already
+     * been shutdown
+     */
+    MANAGER_SHUTDOWN,
+
+    /**
      * If the requested queue could not be found
      */
     QUEUE_NOT_FOUND,

--- a/source/tristanable/manager/manager.d
+++ b/source/tristanable/manager/manager.d
@@ -96,9 +96,33 @@ public class Manager
      */
     public void stop()
     {
+        /* Stop the watcher */
         watcher.shutdown();
 
-        // TODO: Unblock ALL queues here
+        /* Unblock all `dequeue()` calls */
+        shutdownAllQueues();
+    }
+
+    /** 
+     * Shuts down all registered queues
+     */
+    protected void shutdownAllQueues()
+    {
+        /* Lock the queue of queues */
+        queuesLock.lock();
+
+        /* On return or error */
+        scope(exit)
+        {
+            /* Unlock the queue of queues */
+            queuesLock.unlock();
+        }
+
+        /* Shutdown each queue */
+        foreach(Queue queue; this.queues)
+        {
+            queue.shutdownQueue(ErrorType.MANAGER_SHUTDOWN);
+        }
     }
 
     /**

--- a/source/tristanable/manager/manager.d
+++ b/source/tristanable/manager/manager.d
@@ -97,6 +97,8 @@ public class Manager
     public void stop()
     {
         watcher.shutdown();
+
+        // TODO: Unblock ALL queues here
     }
 
     /**

--- a/source/tristanable/manager/manager.d
+++ b/source/tristanable/manager/manager.d
@@ -149,6 +149,8 @@ public class Manager
             queuesLock.unlock();
         }
 
+        // TODO: Shutdown default queue - see mtsafety
+
         /* Shutdown each queue */
         foreach(Queue queue; this.queues)
         {

--- a/source/tristanable/manager/manager.d
+++ b/source/tristanable/manager/manager.d
@@ -93,20 +93,51 @@ public class Manager
      * Stops the management of the socket, resulting
      * in ending the updating of queues and closing
      * the underlying connection
+     *
+     * Calling this will also unblock any calls that
+     * were blocking whilst doing a `dequeue()`
      */
     public void stop()
+    {
+        /* Stop with the given reason */
+        stop(ErrorType.MANAGER_SHUTDOWN);
+    }
+
+    /** 
+     * Only called by the `Watcher` and for
+     * the purpose of setting a custom error
+     * type.
+     *
+     * Called when the network read fails
+     */
+    void stop_FailedWatcher()
+    {
+        /* Stop with the given reason */
+        stop(ErrorType.WATCHER_FAILED);
+    }
+
+    /** 
+     * Stops the watcher service and then
+     * unblocks all calls to `dequeue()`
+     * by shutting down each `Queue`
+     *
+     * Params:
+     *   reason = the reason for the
+     * shutdown
+     */
+    private void stop(ErrorType reason)
     {
         /* Stop the watcher */
         watcher.shutdown();
 
         /* Unblock all `dequeue()` calls */
-        shutdownAllQueues();
+        shutdownAllQueues(reason);
     }
 
     /** 
      * Shuts down all registered queues
      */
-    protected void shutdownAllQueues()
+    protected void shutdownAllQueues(ErrorType reason)
     {
         /* Lock the queue of queues */
         queuesLock.lock();
@@ -121,7 +152,7 @@ public class Manager
         /* Shutdown each queue */
         foreach(Queue queue; this.queues)
         {
-            queue.shutdownQueue(ErrorType.MANAGER_SHUTDOWN);
+            queue.shutdownQueue(reason);
         }
     }
 

--- a/source/tristanable/manager/watcher.d
+++ b/source/tristanable/manager/watcher.d
@@ -128,6 +128,8 @@ public class Watcher : Thread
                 break;
             }
         }
+
+        // TODO: Unblock all `dequeue()`'s here
     }
 
     /** 

--- a/source/tristanable/manager/watcher.d
+++ b/source/tristanable/manager/watcher.d
@@ -308,15 +308,15 @@ unittest
 }
 
 /**
- * Setup a server which dies (kills its connection to us)
- * midway whilst we are doing a `dequeue()`
+ * Setup a `Manager` and then block on a `dequeue()`
+ * but from another thread shutdown the `Manager`.
  *
  * This is to test the exception triggering mechanism
  * for such a case
  */
 unittest
 {
-    writeln("<<<<< Test 4 start >>>>>");
+    writeln("<<<<< Test 3 start >>>>>");
 
     Address serverAddress = parseAddress("::1", 0);
     Socket server = new Socket(AddressFamily.INET6, SocketType.STREAM, ProtocolType.TCP);
@@ -424,15 +424,15 @@ unittest
 }
 
 /**
- * Setup a `Manager` and then block on a `dequeue()`
- * but from another thread shutdown the `Manager`.
+ * Setup a server which dies (kills its connection to us)
+ * midway whilst we are doing a `dequeue()`
  *
  * This is to test the exception triggering mechanism
  * for such a case
  */
 unittest
 {
-    writeln("<<<<< Test 3 start >>>>>");
+    writeln("<<<<< Test 4 start >>>>>");
 
     Address serverAddress = parseAddress("::1", 0);
     Socket server = new Socket(AddressFamily.INET6, SocketType.STREAM, ProtocolType.TCP);

--- a/source/tristanable/manager/watcher.d
+++ b/source/tristanable/manager/watcher.d
@@ -132,7 +132,7 @@ public class Watcher : Thread
         // TODO: Unblock all `dequeue()`'s here
         // TODO: Get a reason for exiting (either cause of error OR shutdoiwn (see below (which in turn is called by the Manager)))
         version(unittest) { writeln("Exited watcher loop"); }
-        this.manager.stop();
+        // this.manager.stop();
     }
 
     /** 

--- a/source/tristanable/manager/watcher.d
+++ b/source/tristanable/manager/watcher.d
@@ -135,6 +135,11 @@ public class Watcher : Thread
         // ... but will just try shutdown an alreayd shutdown manager
         // ... again and try shut our already-closed river stream
         // Shutdown and unblock all `dequeue()` calls
+
+        // TODO: A problem is user-initiated could cause this to trugger first and then throw
+        // ... actually with a WATCHER_FAILED - we should maybe use one error
+        // ... or find a smart way to have the right flow go off - split up calls
+        // ... more?
         this.manager.stop_FailedWatcher();
     }
 


### PR DESCRIPTION
## Purpose :writing_hand: 

We want to unblock all calls to `dequeue()` in two scenarios:

1. If the underlying `Stream` (river stream) has an error (remote host disconnects)
2. If the `stop()` method is called in the `Manager`

## Todo :white_check_mark: 

- [ ] On `stop()`
    - [ ] Implementation
    - [ ] Unittest
- [ ] On `Stream` read failure (would be `BClient` actually)
    - [ ] Implementation
    - [ ] Unittest

## Problems

- [ ] User-initiated `stop()` can trigger `WATCHER_FAILED` as the `BClient` unblocks quicker to then call `stop_FailedWatcher()` triggering to save said exit reason, and then `dequeue()` wakes up before we race to set the **correct** exit reason for it to see instead of the old one
- [ ] Shutdown default queue as well
- [ ] Resources
    - [ ] After shutdown release all queues